### PR TITLE
serve static files if no nginx in charge

### DIFF
--- a/infoscience_exports/urls.py
+++ b/infoscience_exports/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.views.generic import TemplateView
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 from rest_framework.routers import DefaultRouter
 
@@ -27,3 +28,6 @@ urlpatterns = [
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 urlpatterns += django_tequila_urlpatterns
+
+# FIXME: to remove once nginx is intalled on TIND infrastructure
+urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Temporary addition to allow correct configuration of TIND platform

1. gunicorn can serve staticfiles (behind load balancer anyway)
