### PR TITLE
Enhanced prod release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,11 @@ release:
 	git merge release-$(VERSION)
 	git push
 
-git push-prod:
+push-prod:
+	@# confirm push to production
+	@python update_release.py confirm --prod
+
+	# update tags
 	git tag -f prod-release
 	git push --tags
 

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 
 [packages]
 
-Django = "*"
+django = "*"
 dj-database-url = "*"
 django-dirtyfields = "*"
 django-filter = "*"
@@ -17,7 +17,7 @@ django-tequila = {git = "https://github.com/epfl-idevelop/django-tequila.git", e
 djangorestframework = "*"
 gevent = "*"
 gunicorn = "*"
-Markdown = "*"
+markdown = "*"
 "psycopg2-binary" = "*"
 pymarc = "*"
 pytz = "*"
@@ -32,9 +32,9 @@ codecov = "*"
 django-debug-toolbar = "*"
 django-extensions = "*"
 django-nose = "*"
-"Fabric3" = "*"
-factory_boy = "*"
-Faker = "*"
+"fabric3" = "*"
+factory-boy = "*"
+faker = "*"
 "flake8" = "*"
 graypy = "*"
 ipdb = "*"
@@ -44,6 +44,7 @@ mock = "*"
 nose-progressive = "*"
 selenium = "*"
 requests = "*"
+rope = "*"
 
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5cd706c812b9cb1bee5160bbe6e5e21fddc86d73b5017491da35f9fde38dd3eb"
+            "sha256": "fcee6a97fa90875868ee61bdba4ebae0ca7f7abec531fe64d5ec62b5f2e8148f"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -378,10 +378,10 @@
         },
         "coveralls": {
             "hashes": [
-                "sha256:84dd8c88c5754e8db70a682f537e2781366064aa3cdd6b24c2dcecbd3181187c",
-                "sha256:510682001517bcca1def9f6252df6ce730fcb9831c62d9fff7c7d55b6fdabdf3"
+                "sha256:32569a43c9dbc13fa8199247580a4ab182ef439f51f65bb7f8316d377a1340e8",
+                "sha256:664794748d2e5673e347ec476159a9d87f43e0d2d44950e98ed0e27b98da8346"
             ],
-            "version": "==1.2.0"
+            "version": "==1.3.0"
         },
         "cryptography": {
             "hashes": [
@@ -754,12 +754,18 @@
             ],
             "version": "==2.18.4"
         },
+        "rope": {
+            "hashes": [
+                "sha256:a09edfd2034fd50099a67822f9bd851fbd0f4e98d3b87519f6267b60e50d80d1"
+            ],
+            "version": "==0.10.7"
+        },
         "selenium": {
             "hashes": [
-                "sha256:b0a06afa31a80d7dcb627eafb62776488b20bdaffcd807ac4158fadbc11061f4",
-                "sha256:a34a833d89bcfb463bfba5e5515a9276bb94221787b409f0ad28d2f91903e31d"
+                "sha256:60b45c045e9e658ac033ccdafb36000f39088b94336e078c89e8df18d0ef080e",
+                "sha256:6a76deef7d5ea9749e3348b6c1f39df26dbffb9f0ce19ae37bcef02ce9032e41"
             ],
-            "version": "==3.9.0"
+            "version": "==3.10.0"
         },
         "simplegeneric": {
             "hashes": [
@@ -790,13 +796,13 @@
         },
         "tornado": {
             "hashes": [
-                "sha256:92b7ca81e18ba9ec3031a7ee73d4577ac21d41a0c9b775a9182f43301c3b5f8e",
-                "sha256:b36298e9f63f18cad97378db2222c0e0ca6a55f6304e605515e05a25483ed51a",
-                "sha256:ab587996fe6fb9ce65abfda440f9b61e4f9f2cf921967723540679176915e4c3",
-                "sha256:5ef073ac6180038ccf99411fe05ae9aafb675952a2c8db60592d5daf8401f803",
-                "sha256:6d14e47eab0e15799cf3cdcc86b0b98279da68522caace2bd7ce644287685f0a"
+                "sha256:54a568429fb77529622a4607c66f9144aa980bd4fe2326206672707eba6951fc",
+                "sha256:f112ae0b50d2080995afab36aca4fcd93af1fa2e7185b15d854b0d6b2578dce4",
+                "sha256:6b56415667b1ad4f222486baa7118d5445310fd9b99a2263e029bc63df6e2e80",
+                "sha256:4b6a623a28307c5d5d64b34ed7c84f2bfcc6848fd71546bb8bc03dd82b71ad04",
+                "sha256:62f754562c61ea94b00d61727202105068bc2760f076cc34d2da1a57041731aa"
             ],
-            "version": "==4.5.3"
+            "version": "==5.0"
         },
         "traitlets": {
             "hashes": [

--- a/infoscience_exports/exports/versions.py
+++ b/infoscience_exports/exports/versions.py
@@ -3,7 +3,7 @@
 
 # the release comes from git and should not be modified
 # => read-only
-_release = '0.3.1-4-g0524445'
+_release = '0.3.1-4-g7087f28'
 
 # you can set the next version number manually
 # if you do not, the system will make sure that version > release
@@ -13,4 +13,4 @@ _version = '0.3.2-rc'
 # the build number will generate conflicts on each PR merge
 # just keep yours every time
 # => read-only
-_build = '05244454f0ae2193eeb8729e883291f84e0d3eff'
+_build = '7087f287449164ef0e213d4e67c15e93b0926d34'

--- a/infoscience_exports/exports/versions.py
+++ b/infoscience_exports/exports/versions.py
@@ -3,7 +3,7 @@
 
 # the release comes from git and should not be modified
 # => read-only
-_release = '0.3.1-5-g43fc7ec'
+_release = '0.3.1-6-gb6e4a39'
 
 # you can set the next version number manually
 # if you do not, the system will make sure that version > release
@@ -13,4 +13,4 @@ _version = '0.3.2-rc'
 # the build number will generate conflicts on each PR merge
 # just keep yours every time
 # => read-only
-_build = '43fc7ecccae9888a208a30e5118885d4f18cbb8d'
+_build = 'b6e4a39489a3d235fbc9f27104d361494eddfbe4'

--- a/infoscience_exports/exports/versions.py
+++ b/infoscience_exports/exports/versions.py
@@ -3,7 +3,7 @@
 
 # the release comes from git and should not be modified
 # => read-only
-_release = '0.3.1-4-g7087f28'
+_release = '0.3.1-5-g43fc7ec'
 
 # you can set the next version number manually
 # if you do not, the system will make sure that version > release
@@ -13,4 +13,4 @@ _version = '0.3.2-rc'
 # the build number will generate conflicts on each PR merge
 # just keep yours every time
 # => read-only
-_build = '7087f287449164ef0e213d4e67c15e93b0926d34'
+_build = '43fc7ecccae9888a208a30e5118885d4f18cbb8d'

--- a/infoscience_exports/exports/versions.py
+++ b/infoscience_exports/exports/versions.py
@@ -3,14 +3,14 @@
 
 # the release comes from git and should not be modified
 # => read-only
-_release = '0.3.0-16-gf50c490'
+_release = '0.3.1-4-g0524445'
 
 # you can set the next version number manually
 # if you do not, the system will make sure that version > release
 # => read-write, >_release
-_version = '0.3.1'
+_version = '0.3.2-rc'
 
 # the build number will generate conflicts on each PR merge
 # just keep yours every time
 # => read-only
-_build = 'f50c490acbbdf62d1f915f9fd5acc34731e8194f'
+_build = '05244454f0ae2193eeb8729e883291f84e0d3eff'

--- a/update_release.py
+++ b/update_release.py
@@ -124,7 +124,7 @@ try: input = raw_input
 except: pass
 
 
-def confirm():
+def confirm_release():
     print("version currently set to {}".format(_version))
     answer = ""
     while answer not in ["y", "n"]:
@@ -199,7 +199,7 @@ It can be run with both python 2.7 and 3.6""")
     logging.debug(args)
 
     if args.command == 'confirm':
-        if not confirm():
+        if not confirm_release():
             raise SystemExit("Please confirm version number to continue")
     elif args.command == 'check':
         check_branch(expected=args.branch)

--- a/update_release.py
+++ b/update_release.py
@@ -129,7 +129,23 @@ def confirm_release():
     answer = ""
     while answer not in ["y", "n"]:
         answer = input("OK to push to continue [Y/N]? ").lower()
-    return answer == "y"
+    if answer != "y":
+        raise SystemExit("Please confirm version number to continue")
+
+
+def confirm_push():
+    try:
+        branch = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=BASE_DIR).decode('utf-8').strip()
+        print("\nYou are on branch '{}'".format(branch))
+        print("on version        '{}'".format(_version))
+        print("\nType [y] to comfirm push".format(branch))
+        answer = input("or any other key to abort:").lower()
+        if answer != "y":
+            raise SystemExit("Push aborted...")
+    except Exception as err:
+        logging.warning("Git does not seem available: %s", err)
+        raise SystemExit("This command requires git")
 
 
 def publish(dry_run=False):
@@ -187,9 +203,10 @@ if __name__ == '__main__':
 
 This file should be used as post-commit in .git/hooks
 It can be run with both python 2.7 and 3.6""")
-    parser.add_argument("command", nargs='?', help="[confirm|public|check]")
-    parser.add_argument('--branch', help="used with command check_branch")
+    parser.add_argument("command", nargs='?', help="[confirm|publish|check]")
+    parser.add_argument('--prod', action='store_true', help="used with command confirm")
     parser.add_argument('--dry-run', action='store_true', help="used with command publish")
+    parser.add_argument('--branch', help="used with command check_branch")
     parser.add_argument('-v', '--version', action='version', version=_version)
     parser.add_argument('-d', '--debug', action='store_true')
     parser.add_argument('-q', '--quiet', action='store_true')
@@ -199,8 +216,10 @@ It can be run with both python 2.7 and 3.6""")
     logging.debug(args)
 
     if args.command == 'confirm':
-        if not confirm_release():
-            raise SystemExit("Please confirm version number to continue")
+        if args.prod:
+            confirm_push()
+        else:
+            confirm_release()
     elif args.command == 'check':
         check_branch(expected=args.branch)
     elif args.command == 'publish':

--- a/update_release.py
+++ b/update_release.py
@@ -90,7 +90,7 @@ def compute():
             ["git", "rev-parse", "HEAD"], cwd=BASE_DIR).decode('utf-8').strip()
 
         release = subprocess.check_output(
-            ["git", "describe", "--tags"], cwd=BASE_DIR).decode('utf-8').strip()
+            ["git", "describe", "--tags", "--match", "[0-9]*"], cwd=BASE_DIR).decode('utf-8').strip()
     except Exception as err:
         logging.warning("Using previous build & release, since git does not seem available: %s", err)
         release = _release


### PR DESCRIPTION
- added confirmation before pushing to production
- ignore tags `qa-release` and `prod-realease` when building up versions.py
- (more accurately: only consider tags starting with a number)