### PR TITLE
Add url fetcher from parameter when creating an export

### DIFF
--- a/infoscience_exports/exports/marc21xml.py
+++ b/infoscience_exports/exports/marc21xml.py
@@ -241,7 +241,8 @@ def import_marc21xml(url, can_display_pending_publications):
     result = []
 
     o = urlparse(url)
-    if o.netloc not in settings.ALLOWED_HOSTS:
+    if not '*' in settings.ALLOWED_HOSTS and \
+            o.netloc not in settings.ALLOWED_HOSTS:
         result.append({'error': _('The domain is not allowed')})
         return result
 

--- a/infoscience_exports/exports/test/test_selenium.py
+++ b/infoscience_exports/exports/test/test_selenium.py
@@ -93,7 +93,19 @@ class SeleniumStaticLiveServerTestCase(StaticLiveServerTestCase):
     def test_url_as_paramter_will_autofill_form(self):
         full_url = '%s%s' % (self.live_server_url,
                              reverse('crud:export-create'))
-        infoscience_url = 'https://infoscience.epfl.ch/search?ln=en&p=vetterli' \
+
+        infoscience_url = '{}/search%3Fln%3Den%26p%3Dvetterli%26f%3D%26c%3DInfoscience%252FArticle' \
+                          '%26c%3DInfoscience%252FReview%26c%3DInfoscience%252FThesis' \
+                          '%26c%3DInfoscience%252FWorking%2Bpapers%26c%3DInfoscience%252FProceedings' \
+                          '%26c%3DInfoscience%252FPresentation%26c%3DInfoscience%252FPatent' \
+                          '%26c%3DInfoscience%252FStudent%26c%3DMedia%26c%3DOther%2Bdoctypes' \
+                          '%26c%3DInfoscience%252FConference%26c%3DInfoscience%252FReport%26c%3DInfoscience%252FBook' \
+                          '%26c%3DInfoscience%252FChapter%26c%3DInfoscience%252FPoster%26c%3DInfoscience%252FStandard' \
+                          '%26c%3DInfoscience%252FLectures%26c%3DInfoscience%252FDataset' \
+                          '%26c%3DInfoscience%252FPhysical%2Bobjects%26c%3DWork%2Bdone%2Boutside%2BEPFL' \
+                          '%26sf%3D%26so%3Dd%26rg%3D10'.format(quote(settings.INFOSCIENCE_SITE_URL, safe=''))
+
+        awaited_result_url = '{}/search?ln=en&p=vetterli' \
                           '&f=&c=Infoscience%2FArticle&c=Infoscience%2FReview&c=Infoscience%2FThesis' \
                           '&c=Infoscience%2FWorking+papers&c=Infoscience%2FProceedings' \
                           '&c=Infoscience%2FPresentation&c=Infoscience%2FPatent&c=Infoscience%2FStudent' \
@@ -101,17 +113,7 @@ class SeleniumStaticLiveServerTestCase(StaticLiveServerTestCase):
                           '&c=Infoscience%2FBook&c=Infoscience%2FChapter&c=Infoscience%2FPoster&c=Infoscience%2FStandard' \
                           '&c=Infoscience%2FLectures&c=Infoscience%2FDataset' \
                           '&c=Infoscience%2FPhysical+objects&c=Work+done+outside+EPFL' \
-                          '&sf=&so=d&rg=10'
-
-        awaited_result_url = 'https://infoscience.epfl.ch/search?ln=en&p=vetterli' \
-                          '&f=&c=Infoscience/Article&c=Infoscience/Review&c=Infoscience/Thesis' \
-                          '&c=Infoscience/Working+papers&c=Infoscience/Proceedings' \
-                          '&c=Infoscience/Presentation&c=Infoscience/Patent&c=Infoscience/Student' \
-                          '&c=Media&c=Other+doctypes&c=Infoscience/Conference&c=Infoscience/Report' \
-                          '&c=Infoscience/Book&c=Infoscience/Chapter&c=Infoscience/Poster&c=Infoscience/Standard' \
-                          '&c=Infoscience/Lectures&c=Infoscience/Dataset' \
-                          '&c=Infoscience/Physical+objects&c=Work+done+outside+EPFL' \
-                          '&sf=&so=d&rg=10'
+                          '&sf=&so=d&rg=10'.format(settings.INFOSCIENCE_SITE_URL)
 
         full_url = '{}?url={}'.format(full_url, quote(infoscience_url, safe=''))
 

--- a/infoscience_exports/exports/views.py
+++ b/infoscience_exports/exports/views.py
@@ -1,3 +1,5 @@
+from urllib.parse import unquote
+
 from django.urls import reverse_lazy as django_reverse_lazy
 from django.http import HttpResponse
 from django.template import loader
@@ -49,6 +51,15 @@ class ExportCreate(LoginRequiredMixin, CreateView):
     model = Export
     form_class = ExportForm
     success_url = django_reverse_lazy('crud:export-list')
+
+    def get(self, request, *args, **kwargs):
+        # url in parameter is a form initial
+        if request.GET.get('url'):
+            self.initial.update({
+                'url': unquote(request.GET['url'])
+            })
+
+        return super().get(request, *args, **kwargs)
 
     def form_valid(self, form):
         form.instance.user = self.request.user

--- a/infoscience_exports/settings/test.py
+++ b/infoscience_exports/settings/test.py
@@ -18,6 +18,9 @@ NOSE_ARGS = [
     '--cover-package={}'.format(BASE_DIR)
 ]
 
+# for test verification at the moment
+INFOSCIENCE_SITE_URL = 'https://infoscience.epfl.ch'
+
 # no auth for tests
 AUTHENTICATION_BACKENDS = ('exports.test.auth_backends.TestcaseUserBackend', )
 


### PR DESCRIPTION
Lire le test, on peut voir que toute l'url est "unquotée". Cela fonctionne aussi, c'est juste qu'il y aura deux formats d'url sauvé dans la BD, un unquoté et un quoté, selon l'origine de la création de l'export.

Tenez-moi au courant si ce n'est pas acceptable.