### PR TITLE
Fix loggout process on dev

### DIFF
--- a/infoscience_exports/settings/base.py
+++ b/infoscience_exports/settings/base.py
@@ -34,6 +34,8 @@ AUTH_USER_MODEL = 'exports.User'
 # override django-tequila urls if we are serving the application from a folder path
 LOGIN_URL = "{}/login".format(SITE_PATH)
 LOGIN_REDIRECT_URL = "{}".format(SITE_PATH)
+# this is the invenio logout, so when we finished logging out the user,
+# sending him here will invalid is invenio session too.
 LOGOUT_URL = "/youraccount/logout"
 LOGIN_REDIRECT_IF_NOT_ALLOWED = "{}/not_allowed".format(SITE_PATH)
 LOGIN_REDIRECT_TEXT_IF_NOT_ALLOWED = "Not allowed"

--- a/infoscience_exports/settings/test.py
+++ b/infoscience_exports/settings/test.py
@@ -21,6 +21,9 @@ NOSE_ARGS = [
 # for test verification at the moment
 INFOSCIENCE_SITE_URL = 'https://infoscience.epfl.ch'
 
+# as we don't have invenio in backend, send here for logged out confirmation
+LOGOUT_URL = "{}/logged-out/".format(SITE_PATH)
+
 # no auth for tests
 AUTHENTICATION_BACKENDS = ('exports.test.auth_backends.TestcaseUserBackend', )
 


### PR DESCRIPTION
Par accident, le loggout de infoscience-export fait aussi le logout d'invenio. Est-ce un heureux hasard et/ou comportement souhaité ?

Ce fix est pour le dév. seulement.