### PR TITLE
Add a 15 min db cache for reading exports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ init-db:
 		python infoscience_exports/manage.py makemigrations
 	docker-compose -f docker-compose-dev.yml exec web \
 		python infoscience_exports/manage.py migrate
+	# make a room for the cache
+	docker-compose -f docker-compose-dev.yml exec web \
+		python infoscience_exports/manage.py createcachetable
 	# create super admin in app
 	make superadmin
 	@echo "  -> All set up! You can connect with your tequila acount or the admin (${SUPER_ADMIN_EMAIL})"

--- a/infoscience_exports/exports/urls.py
+++ b/infoscience_exports/exports/urls.py
@@ -1,9 +1,10 @@
 from django.conf.urls import url, include
+from django.views.decorators.cache import cache_page
 from exports import views
 
 export_patterns = ([
     url(r'^$', views.ExportList.as_view(), name='export-list'),
-    url(r'^(?P<pk>\d+)/$', views.ExportView.as_view(), name='export-view'),
+    url(r'^(?P<pk>\d+)/$', cache_page(60*15)(views.ExportView.as_view()), name='export-view'),
     url(r'^new/$', views.ExportCreate.as_view(), name='export-create'),
     url(r'^(?P<pk>\d+)/update/$', views.ExportUpdate.as_view(), name='export-update'),
     url(r'^(?P<pk>\d+)/delete/$', views.ExportDelete.as_view(), name='export-delete'),

--- a/infoscience_exports/settings/base.py
+++ b/infoscience_exports/settings/base.py
@@ -214,7 +214,7 @@ CACHES = {
         'TIMEOUT': None, # persistant, at least until MAX_ENTRIES
         'OPTIONS': {
             'MAX_ENTRIES': 3000, # default is 300
-            'CULL_FREQUENCY': 5, # 1/5 of the cache is clean when max entry is reached
+            'CULL_FREQUENCY': 5, # 1/5 of the cache is cleaned when max entry is reached
         }
     }
 }

--- a/infoscience_exports/settings/base.py
+++ b/infoscience_exports/settings/base.py
@@ -206,3 +206,15 @@ LOGGING = {
         },
     }
 }
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'generated_export_cache',
+        'TIMEOUT': None, # persistant, at least until MAX_ENTRIES
+        'OPTIONS': {
+            'MAX_ENTRIES': 3000, # default is 300
+            'CULL_FREQUENCY': 5, # 1/5 of the cache is clean when max entry is reached
+        }
+    }
+}


### PR DESCRIPTION
Attention, il faut commenter le DummyCache si vous voulez voir le changement en dév ou en test.

https://github.com/epfl-idevelop/infoscience-exports/blob/07c88c2e05a1f73e80438797283a262dd21a3651/infoscience_exports/settings/test.py#L30

